### PR TITLE
Update build target gates

### DIFF
--- a/sleep/compile_error.go
+++ b/sleep/compile_error.go
@@ -1,0 +1,6 @@
+// +build go1.17
+
+package sleep
+
+// Force a compile error to "output" a message.
+const compileError int = "This package requires manual checks before it can be built on Go 1.17+. See https://github.com/getlantern/netstack/pull/6"

--- a/sleep/sleep_unsafe.go
+++ b/sleep/sleep_unsafe.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // +build go1.11
-// +build !go1.16
+// +build !go1.17
 
 // Check go:linkname function signatures when updating Go version.
 

--- a/tcpip/compile_error.go
+++ b/tcpip/compile_error.go
@@ -1,0 +1,6 @@
+// +build go1.17
+
+package tcpip
+
+// Force a compile error to "output" a message.
+const compileError int = "This package requires manual checks before it can be built on Go 1.17+. See https://github.com/getlantern/netstack/pull/6"

--- a/tcpip/link/rawfile/blockingpoll_yield_unsafe.go
+++ b/tcpip/link/rawfile/blockingpoll_yield_unsafe.go
@@ -14,7 +14,7 @@
 
 // +build linux,amd64 linux,arm64
 // +build go1.12
-// +build !go1.16
+// +build !go1.17
 
 // Check go:linkname function signatures when updating Go version.
 

--- a/tcpip/link/rawfile/compile_error.go
+++ b/tcpip/link/rawfile/compile_error.go
@@ -1,0 +1,6 @@
+// +build go1.17
+
+package rawfile
+
+// Force a compile error to "output" a message.
+const compileError int = "This package requires manual checks before it can be built on Go 1.17+. See https://github.com/getlantern/netstack/pull/6"

--- a/tcpip/time_unsafe.go
+++ b/tcpip/time_unsafe.go
@@ -13,7 +13,7 @@
 // limitations under the License.
 
 // +build go1.9
-// +build !go1.16
+// +build !go1.17
 
 // Check go:linkname function signatures when updating Go version.
 


### PR DESCRIPTION
I checked all of these links and they're still valid, so we should be good to go.

If you're coming here from the future, wondering how to make this repo build for Go 1.17+, here are a few pointers: This repo utilizes a few unexported types and functions from the standard library, using `go:linkname` directives.  When building with a new version of Go, we need to check to make sure these linked types and functions still exist; the compiler will not check for us and we'll get weird runtime failures if the links are broken.

To update, go to each file with a `!go1.17` build constraint.  Search the file for `go:linkname` directives.  Search the standard library Go 1.17 source code for each of the linked names (e.g. `grep -nw "func entersyscallblock" $GOROOT/src/runtime/*`).  If the standard-library file defining the name has build constraints, double-check that these still support netstack's use of the name.  Once each of the linked names in a file are verified, update the build constraint to exclude the next version of Go, forcing this check again on the next update to the standard library.